### PR TITLE
Fixing accessibility frame determination for links

### DIFF
--- a/TTTAttributedLabel/TTTAttributedLabel.m
+++ b/TTTAttributedLabel/TTTAttributedLabel.m
@@ -848,6 +848,7 @@ static inline CGSize CTFramesetterSuggestFrameSizeForAttributedStringWithConstra
     [textStorage addLayoutManager:layoutManager];
 
     NSTextContainer *textContainer = [[NSTextContainer alloc] initWithSize:self.bounds.size];
+    textContainer.lineFragmentPadding = 0;
     [layoutManager addTextContainer:textContainer];
 
     NSRange glyphRange;


### PR DESCRIPTION
## Description

Prior to this change, a link's accessibility frame is mis-computed in certain situations, which causes issues for systems that rely on the accessibility frame (VoiceOver, KIF). The specific issue this change is addressing was a KIF test failure due to attempting to tap the wrong location -- see <issue_tracking_link> for more context.

The bounding rect (and therefore the accessibility frame) of links is calculated by a NSLayoutManager instance created specifically for this purpose, with input of a NSTextContainer instance. NSTextContainer has a default [`lineFragmentPadding`](https://developer.apple.com/documentation/uikit/nstextcontainer/1444527-linefragmentpadding) of 5.0. It seems like that that same `lineFragmentPadding` was not being applied during TTTAttributedLabel's `drawTextInRect:` implementation, causing a misalignment of what each.

This change sets the NSTextContainer's `lineFragmentPadding` to 0, which causes the accessibility frame to match the layout produced by `drawTextInRect:` when the text is left-aligned. (Center-aligned text is unaffected by this change, since it doesn't rely on left/right padding for layout or determining its accessibility frame).

### Risk analysis

This change only affects `boundingRectForCharacterRange:`, which is used only to determine a link accessibility element's `boundingRect`, which in turn is used only to compute the accessibility element's `accessibilityFrame`.

So this change is limited in scope to only affect accessibility frames of link elements.

### Screenshots

#### Before

![Screen Shot 2020-06-02 at 12 04 25 PM](https://user-images.githubusercontent.com/1123786/83559404-61896f00-a4c9-11ea-90b2-030cec3ff9e9.png)

#### After

![Screen Shot 2020-06-02 at 11 43 36 AM](https://user-images.githubusercontent.com/1123786/83559403-5fbfab80-a4c9-11ea-97ba-1d9c434bba0d.png)

## QA Plan

- [x] Confirm across all Quizlet app uses of the label that this produces the correct behavior
  - 🗒️ : All uses of TTTAttributedLabel other than the example that prompted this fix use center-aligned text, which doesn't exhibit this same issue, but they continue to work properly after this change