### PR TITLE
Updating version in podspec to prepare for creating new release

### DIFF
--- a/TTTAttributedLabel.podspec
+++ b/TTTAttributedLabel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'TTTAttributedLabel'
-  s.version      = '1.13.4-quizlet'
+  s.version      = 'quizlet-1'
   s.authors      = { 'Mattt Thompson' => 'm@mattt.me' }
   s.homepage     = 'https://github.com/TTTAttributedLabel/TTTAttributedLabel'
   s.platform     = :ios


### PR DESCRIPTION
## Description

Updated version in podspec to prepare for creating new release

Used `quizlet-1` as the version name to help clarify that we're not close to any official version of TTTAttributedLabel (see  https://github.com/TTTAttributedLabel/TTTAttributedLabel/releases) -- we forked somewhere between 1.13.4 and 2.0.0, and now we're in our own world.