### PR TITLE
Revert "Updating version in podspec to prepare for creating new release"

### DIFF
--- a/TTTAttributedLabel.podspec
+++ b/TTTAttributedLabel.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'TTTAttributedLabel'
-  s.version      = 'quizlet-1'
+  s.version      = '1.13.4-quizlet'
   s.authors      = { 'Mattt Thompson' => 'm@mattt.me' }
   s.homepage     = 'https://github.com/TTTAttributedLabel/TTTAttributedLabel'
   s.platform     = :ios


### PR DESCRIPTION
Reverts quizlet/TTTAttributedLabel#3

This sadly breaks pod install:
```
Analyzing dependencies
Pre-downloading: `TTTAttributedLabel` from `https://github.com/quizlet/TTTAttributedLabel.git`, tag `quizlet-1`
[!] Failed to load 'TTTAttributedLabel' podspec: 
[!] Invalid `TTTAttributedLabel.podspec` file: Malformed version number string quizlet-1.

 #  from /var/folders/gp/psyjdzms01n4j8c7x2ns160h0000gn/T/d20200603-55849-1ey7n0n/TTTAttributedLabel.podspec:8
 #  -------------------------------------------
 #    s.summary      = 'A drop-in replacement for UILabel that supports attributes, data detectors, links, and more.'
 >    s.source       = { :git => 'https://github.com/quizlet/TTTAttributedLabel.git', :tag => s.version }
 #    s.license      = 'MIT'
 #  -------------------------------------------
```